### PR TITLE
Fix HTML charset to UTF-8

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -4,7 +4,7 @@
 
 <title>智慧家</title>
 
-<meta http-equiv="Content-Type" content="text/html; charset=utf8">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
 </head>
 


### PR DESCRIPTION
## Summary
- change meta charset declaration to `utf-8`

## Testing
- `python - <<'PY'
from html.parser import HTMLParser
import sys

class Parser(HTMLParser):
    def error(self, message):
        raise Exception(message)

p = Parser()
with open('index.htm') as f:
    data = f.read()

p.feed(data)
print('Parsed without errors')
PY`
- ⚠️ `tidy -q -e index.htm` *(fails: command not found)*
- ⚠️ `npx --yes html-validate index.htm` *(fails: 403 Forbidden)*
- ⚠️ `pip install html5lib` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68955ae08d7c83238f8099227fa0dec4